### PR TITLE
add travil-ci file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/delveAppengine

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: go
+sudo: false
+os:
+  - linux
+  - osx
+go_import_path: github.com/dbenque/delveAppengine
+go:
+  - 1.6.2
+  - tip
+install: echo "do nothing"
+matrix:
+  allow_failures:
+    - os: osx
+env:
+  global:
+    - GO15VENDOREXPERIMENT=1
+script: go build &&  go test

--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# Delve Appengine
+
+[![Build Status](https://travis-ci.org/cedriclam/delveAppengine.svg?branch=master)](https://travis-ci.org/cedriclam/delveAppengine)


### PR DESCRIPTION
thanks to this PR, you will be able to test your code on several platforms; for now (linux, osx)
also on several Golang version: 1.6.2 and tip

You can see how it will look (on my fork): https://travis-ci.org/cedriclam/delveAppengine/builds/137626572
-> OSX build failed since the current code is not compatible
