### PR TITLE
remove directory name

### DIFF
--- a/process_darwin.go
+++ b/process_darwin.go
@@ -110,7 +110,6 @@ func binaryContainsMagicKey(pid int, key string) bool {
 }
 
 func processes() ([]DarwinProcess, error) {
-	fmt.Println("processes")
 	darwinLock.Lock()
 	defer darwinLock.Unlock()
 	darwinProcs = make([]DarwinProcess, 0, 50)

--- a/process_darwin.go
+++ b/process_darwin.go
@@ -43,7 +43,8 @@ func (p *DarwinProcess) PPid() int {
 
 // Executable returns the executable name
 func (p *DarwinProcess) Executable() string {
-	return p.binary
+	s := strings.Split(p.binary, "/")
+	return s[len(s)-1]
 }
 
 // StartTime returns process Start time


### PR DESCRIPTION
On my Mac, `Executable()` returns a binary path which includes directory such as `/var/folders/mq/m9_twy8j1vl9ppr6j5xqtfq80000gn/T/tmpb5cHODappengine-go-bin/_go_app`.
So I add a code which removes directory path.
